### PR TITLE
Change value types to string

### DIFF
--- a/api_docs_invoice.go
+++ b/api_docs_invoice.go
@@ -18,7 +18,7 @@ type CreateInvoiceRequest struct {
 	Language           string                  `json:"language,omitempty"`
 	Precision          types.Int               `json:"precision,omitempty"`
 	Currency           string                  `json:"currency,omitempty"`
-	ExchangeRate       int                     `json:"exchangeRate,omitempty"`
+	ExchangeRate       string                  `json:"exchangeRate,omitempty"`
 	Products           []types.DocumentRow     `json:"products,omitempty"`
 	IssuerName         string                  `json:"issuerName,omitempty"`
 	IssuerID           string                  `json:"issuerId,omitempty"`

--- a/types/docs.go
+++ b/types/docs.go
@@ -46,7 +46,7 @@ type Collect struct {
 	Type           CollectType `json:"type,omitempty"`
 	SeriesName     string      `json:"seriesName,omitempty"`
 	DocumentNumber string      `json:"documentNumber,omitempty"`
-	Value          int         `json:"value,omitempty"`
+	Value          string      `json:"value,omitempty"`
 	IssueDate      Date        `json:"issueDate,omitempty"`
 	Mentions       string      `json:"mentions,omitempty"`
 }


### PR DESCRIPTION
This pr changes the value types from `int` to `string` to match the `invoice.total` value type.